### PR TITLE
bump release number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def find_stubs(package):  # type: ignore
 
 setup(
     name='pynamodb-attributes',
-    version='0.2.3',
+    version='0.2.4',
     description='Common attributes for PynamoDB',
     url='https://www.github.com/lyft/pynamodb-attributes',
     maintainer='Lyft',


### PR DESCRIPTION
do i need to do `0.2.5` since i already made a release tag, or is it fine to do `0.2.4` since that release failed?