### PR TITLE
[wip] handle union/optional fields in a tuple

### DIFF
--- a/pynamodb_attributes/unicode_delimited_tuple.py
+++ b/pynamodb_attributes/unicode_delimited_tuple.py
@@ -44,7 +44,19 @@ class UnicodeDelimitedTupleAttribute(Attribute, Generic[T]):
         field_types = getattr(self.tuple_type, '_field_types', None)
         if fields and field_types:
             values = value.split(self.delimiter, maxsplit=len(fields))
-            return self.tuple_type(**{f: field_types[f](v) for f, v in zip(fields, values)})  # type: ignore
+        tuple_vals = {}
+        for f, v in zip(fields, values):
+            if field_types[f].__module__ == 'builtins':
+                tuple_vals[f] = field_types[f](v)
+            elif field_types[f].__module__ == 'typing' and field_types[f].__origin__ == typing.Union:
+                for arg_type in field_types[f].__args__:
+                    try:
+                        tuple_vals[f] = arg_type(v)
+                        break
+                    except Exception:
+                        continue
+
+            return self.tuple_type(**tuple_vals)  # type: ignore
         else:
             return self.tuple_type(value.split(self.delimiter))  # type: ignore
 


### PR DESCRIPTION
when you have a tuple where a type of the field is `Optional[*]` it becomes a `Union` type and breaks when trying to deserialize `None` to whatever value it expects.

Adding a check that if it's explicitly a union type, attempt to use all the args, whichever works first to allow that through, if a type error arises, just ignore it.

problems right now:
1. if it's a union of type [`str`, `int`] and the value is something like `42`, the first arg type would succeed -- taking suggestions on other ways to handle this if any.
2. nested unions don't work