### PR TITLE
Update `flake8` settings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,8 @@ license_file = LICENSE
 
 [flake8]
 format = pylint
-exclude = .svc,CVS,.bzr,.hg,.git,__pycache__,venv
 max-complexity = 10
 max-line-length = 120
-ignore = NONE
 
 [tool:pytest]
 addopts = --cov=pynamodb_attributes --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv


### PR DESCRIPTION
- `exclude` - not relevant for how `pre-commit` runs `flake8`
- `ignore` - not relevant for newer versions of `flake8` and even for older ones it was not quite the right away to achieve broad linter selection