### PR TITLE
Remove deprecated _field_types attribute for Python 3.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python-version:
           - "3.8"
+          - "3.9"
 
     services:
       dynamodb-local:

--- a/pynamodb_attributes/unicode_delimited_tuple.py
+++ b/pynamodb_attributes/unicode_delimited_tuple.py
@@ -40,7 +40,7 @@ class UnicodeDelimitedTupleAttribute(Attribute[T]):
 
     def deserialize(self, value: str) -> T:
         fields = getattr(self.tuple_type, '_fields', None)
-        field_types = getattr(self.tuple_type, '_field_types', None)
+        field_types = getattr(self.tuple_type, '__annotations__', None)
         if fields and field_types:
             values = value.split(self.delimiter, maxsplit=len(fields))
             return self.tuple_type(**{f: field_types[f](v) for f, v in zip(fields, values)})

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -16,8 +16,8 @@ def test_integer_attribute():
     class MyModel(Model):
         my_attr = IntegerAttribute()
 
-    reveal_type(MyModel.my_attr)  # E: Revealed type is 'pynamodb_attributes.integer.IntegerAttribute'
-    reveal_type(MyModel().my_attr)  # E: Revealed type is 'builtins.int*'
+    reveal_type(MyModel.my_attr)  # E: Revealed type is "pynamodb_attributes.integer.IntegerAttribute"
+    reveal_type(MyModel().my_attr)  # E: Revealed type is "builtins.int*"
     """)
 
 
@@ -29,8 +29,8 @@ def test_integer_date_attribute():
     class MyModel(Model):
         my_attr = IntegerDateAttribute()
 
-    reveal_type(MyModel.my_attr)  # E: Revealed type is 'pynamodb_attributes.integer_date.IntegerDateAttribute'
-    reveal_type(MyModel().my_attr)  # E: Revealed type is 'datetime.date*'
+    reveal_type(MyModel.my_attr)  # E: Revealed type is "pynamodb_attributes.integer_date.IntegerDateAttribute"
+    reveal_type(MyModel().my_attr)  # E: Revealed type is "datetime.date*"
     """)
 
 
@@ -47,9 +47,9 @@ def test_unicode_delimited_tuple_attribute():
     class MyModel(Model):
         my_attr = UnicodeDelimitedTupleAttribute(MyTuple)
 
-    reveal_type(MyModel.my_attr)  # E: Revealed type is 'pynamodb_attributes.unicode_delimited_tuple.UnicodeDelimitedTupleAttribute[Tuple[builtins.str, builtins.str, fallback=__main__.MyTuple]]'
-    reveal_type(MyModel().my_attr)  # E: Revealed type is 'Tuple[builtins.str, builtins.str, fallback=__main__.MyTuple]'
-    reveal_type(MyModel().my_attr.foo)  # E: Revealed type is 'builtins.str'
+    reveal_type(MyModel.my_attr)  # E: Revealed type is "pynamodb_attributes.unicode_delimited_tuple.UnicodeDelimitedTupleAttribute[Tuple[builtins.str, builtins.str, fallback=__main__.MyTuple]]"
+    reveal_type(MyModel().my_attr)  # E: Revealed type is "Tuple[builtins.str, builtins.str, fallback=__main__.MyTuple]"
+    reveal_type(MyModel().my_attr.foo)  # E: Revealed type is "builtins.str"
     """)  # noqa: E501
 
 
@@ -60,14 +60,14 @@ def test_unicode_enum_attribute():
     from pynamodb_attributes import UnicodeEnumAttribute
 
     class MyEnum(Enum):
-        foo = 'foo'
-        bar = 'bar'
+        foo = "foo"
+        bar = "bar"
 
     class MyModel(Model):
         my_attr = UnicodeEnumAttribute(MyEnum)
 
-    reveal_type(MyModel.my_attr)  # E: Revealed type is 'pynamodb_attributes.unicode_enum.UnicodeEnumAttribute[__main__.MyEnum]'
-    reveal_type(MyModel().my_attr)  # E: Revealed type is '__main__.MyEnum*'
+    reveal_type(MyModel.my_attr)  # E: Revealed type is "pynamodb_attributes.unicode_enum.UnicodeEnumAttribute[__main__.MyEnum]"
+    reveal_type(MyModel().my_attr)  # E: Revealed type is "__main__.MyEnum*"
     """)  # noqa: E501
 
 
@@ -83,9 +83,9 @@ def test_timedelta_attribute():
         td_us = TimedeltaUsAttribute()
 
     m = MyModel()
-    reveal_type(m.td)  # E: Revealed type is 'datetime.timedelta*'
-    reveal_type(m.td_ms)  # E: Revealed type is 'datetime.timedelta*'
-    reveal_type(m.td_us)  # E: Revealed type is 'datetime.timedelta*'
+    reveal_type(m.td)  # E: Revealed type is "datetime.timedelta*"
+    reveal_type(m.td_ms)  # E: Revealed type is "datetime.timedelta*"
+    reveal_type(m.td_us)  # E: Revealed type is "datetime.timedelta*"
 
     m.save(condition=MyModel.td == timedelta(seconds=5))
     """)
@@ -103,9 +103,9 @@ def test_timestamp_attribute():
         ts_us = TimestampUsAttribute()
 
     m = MyModel()
-    reveal_type(m.ts)  # E: Revealed type is 'datetime.datetime*'
-    reveal_type(m.ts_ms)  # E: Revealed type is 'datetime.datetime*'
-    reveal_type(m.ts_us)  # E: Revealed type is 'datetime.datetime*'
+    reveal_type(m.ts)  # E: Revealed type is "datetime.datetime*"
+    reveal_type(m.ts_ms)  # E: Revealed type is "datetime.datetime*"
+    reveal_type(m.ts_us)  # E: Revealed type is "datetime.datetime*"
 
     m.save(condition=MyModel.ts == datetime.now())
     """)
@@ -119,6 +119,6 @@ def test_uuid_attribute():
     class MyModel(Model):
         my_attr = UUIDAttribute()
 
-    reveal_type(MyModel.my_attr)  # E: Revealed type is 'pynamodb_attributes.uuid.UUIDAttribute'
-    reveal_type(MyModel().my_attr)  # E: Revealed type is 'uuid.UUID*'
+    reveal_type(MyModel.my_attr)  # E: Revealed type is "pynamodb_attributes.uuid.UUIDAttribute"
+    reveal_type(MyModel().my_attr)  # E: Revealed type is "uuid.UUID*"
     """)


### PR DESCRIPTION
The `_field_types` attribute was marked as deprecated for a while and was removed in favor of using `__annotations__` in Python 3.9: https://bugs.python.org/issue40182

I also had to fix some of the Mypy test formatting because the error messages were changed to use double quotes https://github.com/python/mypy/issues/7445