### PR TITLE
Fix deprecated  `UnicodeDelimitedTuple` due to deprecated `_field_types`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python-version:
           - "3.8"
+          - "3.9"
 
     services:
       dynamodb-local:

--- a/pynamodb_attributes/timedelta.py
+++ b/pynamodb_attributes/timedelta.py
@@ -7,7 +7,7 @@ from pynamodb.attributes import Attribute
 
 
 class TimedeltaAttribute(Attribute[timedelta]):
-    """ "
+    """
     Stores a timedelta as a number of seconds (truncated).
 
     >>> class MyModel(Model):
@@ -33,7 +33,7 @@ class TimedeltaAttribute(Attribute[timedelta]):
 
 
 class TimedeltaMsAttribute(TimedeltaAttribute):
-    """ "
+    """
     Stores a timedelta as a number of milliseconds AKA ms (truncated).
     """
 
@@ -41,7 +41,7 @@ class TimedeltaMsAttribute(TimedeltaAttribute):
 
 
 class TimedeltaUsAttribute(TimedeltaAttribute):
-    """ "
+    """
     Stores a timedelta as a number of microseconds AKA μs (truncated).
     """
 

--- a/pynamodb_attributes/timestamp.py
+++ b/pynamodb_attributes/timestamp.py
@@ -8,7 +8,7 @@ from pynamodb.attributes import Attribute
 
 
 class TimestampAttribute(Attribute[datetime]):
-    """ "
+    """
     Stores time as a Unix epoch timestamp (in seconds) in a DynamoDB number.
 
     >>> class MyModel(Model):
@@ -37,7 +37,7 @@ class TimestampAttribute(Attribute[datetime]):
 
 
 class TimestampMsAttribute(TimestampAttribute):
-    """ "
+    """
     Stores time as a Unix epoch timestamp in milliseconds (ms) in a DynamoDB number.
     """
 
@@ -45,7 +45,7 @@ class TimestampMsAttribute(TimestampAttribute):
 
 
 class TimestampUsAttribute(TimestampAttribute):
-    """ "
+    """
     Stores times as a Unix epoch timestamp in microseconds (μs) in a DynamoDB number.
     """
 

--- a/pynamodb_attributes/unicode_delimited_tuple.py
+++ b/pynamodb_attributes/unicode_delimited_tuple.py
@@ -51,7 +51,7 @@ class UnicodeDelimitedTupleAttribute(Attribute[T]):
             values = value.split(self.delimiter, maxsplit=len(field_types))
             return self.tuple_type(
                 **{
-                    field_name: self._parse_value(value, field_type)
+                    field_name: field_type(value)
                     for (field_name, field_type), value in zip(
                         field_types.items(),
                         values,
@@ -75,20 +75,3 @@ class UnicodeDelimitedTupleAttribute(Attribute[T]):
                 f"Tuple elements may not contain delimiter '{self.delimiter}'",
             )
         return self.delimiter.join(strings)
-
-    def _parse_value(self, str_value: str, type_: Type[Any]) -> Any:
-        if hasattr(type_, "__args__"):
-            for t in type_.__args__:
-                if isinstance(None, t):
-                    continue
-                try:
-                    return t(str_value)
-                except ValueError:
-                    pass
-            list_of_types = ", ".join(t.__name__ for t in type_.__args__)
-            raise ValueError(
-                f"Unable to parse value: '{str_value}' for any of the "
-                f"following types: '[{list_of_types}]'",
-            )
-        else:
-            return type_(str_value)

--- a/pynamodb_attributes/unicode_delimited_tuple.py
+++ b/pynamodb_attributes/unicode_delimited_tuple.py
@@ -45,14 +45,17 @@ class UnicodeDelimitedTupleAttribute(Attribute[T]):
         self.delimiter = delimiter
 
     def deserialize(self, value: str) -> T:
-        type_hints = get_type_hints(self.tuple_type)
+        field_types = get_type_hints(self.tuple_type)
 
-        if type_hints:
-            values = value.split(self.delimiter, maxsplit=len(type_hints))
+        if field_types:
+            values = value.split(self.delimiter, maxsplit=len(field_types))
             return self.tuple_type(
                 **{
-                    f: self._parse_value(v, type_hints[f])
-                    for f, v in zip(type_hints, values)
+                    field_name: self._parse_value(value, field_type)
+                    for (field_name, field_type), value in zip(
+                        field_types.items(),
+                        values,
+                    )
                 }
             )
         else:

--- a/tests/unicode_delimited_tuple_attribute_test.py
+++ b/tests/unicode_delimited_tuple_attribute_test.py
@@ -1,4 +1,6 @@
 from typing import NamedTuple
+from typing import Optional
+from typing import Union
 from unittest.mock import ANY
 
 import pytest
@@ -13,8 +15,12 @@ from tests.meta import dynamodb_table_meta
 class MyTuple(NamedTuple):
     country: str
     city: str
-    # should be Optional[int] but deserialization does not support it
-    zip_code: int = None  # type: ignore
+    zip_code: Optional[int] = None
+
+
+class MyUnionTuple(NamedTuple):
+    str_or_int_or_none: Union[None, str, int]
+    int_or_str: Union[int, str]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -29,6 +35,7 @@ class MyModel(Model):
     default_delimiter = UnicodeDelimitedTupleAttribute(MyTuple, null=True)
     custom_delimiter = UnicodeDelimitedTupleAttribute(MyTuple, delimiter=".", null=True)
     untyped = UnicodeDelimitedTupleAttribute(tuple, null=True)
+    union_type = UnicodeDelimitedTupleAttribute(MyUnionTuple, null=True)
 
 
 def test_serialization_containing_delimiter(uuid_key):
@@ -141,3 +148,36 @@ def test_serialization_untyped(expected_attributes, value, uuid_key):
     # verify deserialization
     model = MyModel.get(uuid_key)
     assert model.untyped == value
+
+
+@pytest.mark.parametrize(
+    ["raw_input", "expected"],
+    [
+        ({"union_type": {"S": "string::42"}}, MyUnionTuple("string", 42)),
+        (
+            {"union_type": {"S": "string::another_string"}},
+            MyUnionTuple("string", "another_string"),
+        ),
+    ],
+)
+def test_serialization_union_type(raw_input, expected, uuid_key):
+    _connection(MyModel).put_item(
+        hash_key=uuid_key,
+        attributes={"union_type": {"S": "string::42"}},
+    )
+
+    model = MyModel.get(hash_key=uuid_key)
+    assert model.union_type == MyUnionTuple("string", 42)
+
+
+def test_serialization_unparsable_raises(uuid_key):
+    _connection(MyModel).put_item(
+        hash_key=uuid_key,
+        attributes={"default_delimiter": {"S": "US::San Francisco::NOT_A_ZIP_CODE"}},
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"Unable to parse value: 'NOT_A_ZIP_CODE' for any of the following "
+        r"types: '\[int, NoneType\]",
+    ):
+        MyModel.get(hash_key=uuid_key)


### PR DESCRIPTION
This addresses 
* https://github.com/lyft/pynamodb-attributes/issues/32 

The `_field_types` was [removed](https://bugs.python.org/issue40182) in Python 3.9 causing `UnicodeDelimitedTupleAttribute` to not function properly. 
 
This PR needs to be rebased onto https://github.com/lyft/pynamodb-attributes/pull/34