### PR TITLE
Fix Timedelta*Attribute serialization

### DIFF
--- a/pynamodb_attributes/timedelta.py
+++ b/pynamodb_attributes/timedelta.py
@@ -21,8 +21,8 @@ class TimedeltaAttribute(Attribute[timedelta]):
     def deserialize(self, value: str) -> timedelta:
         return timedelta(microseconds=float(value) * (1000000.0 / self._multiplier))
 
-    def serialize(self, td: timedelta) -> int:
-        return int(td.total_seconds() * self._multiplier)
+    def serialize(self, td: timedelta) -> str:
+        return str(int(td.total_seconds() * self._multiplier))
 
     def __set__(self, instance: Any, value: Optional[Any]) -> None:
         if value is not None and not isinstance(value, timedelta):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="pynamodb-attributes",
-    version="0.3.1",
+    version="0.3.2",
     description="Common attributes for PynamoDB",
     url="https://www.github.com/lyft/pynamodb-attributes",
     maintainer="Lyft",


### PR DESCRIPTION
In DynamoDB API, number ("N") data type must be serialized as a JSON string.

Unfortunately moto's dynamodb backend [doesn't fail on this like the real one](https://github.com/spulec/moto/issues/5022), which is why unit tests didn't spot that.