### PR TITLE
Stop tests from being bundled with package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [metadata]
 license_file = LICENSE
 name = pynamodb-attributes
-version = 0.5.1
+version = 0.5.2
 description = Common attributes for PynamoDB
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -20,6 +20,10 @@ packages = find:
 install_requires=
     pynamodb>=5.0.0
 python_requires = >=3
+
+[options.packages.find]
+exclude =
+    tests*
 
 [options.package_data]
 pynamodb_attributes =


### PR DESCRIPTION
Currently `pynamodb-attributes` is bundling its test suite into `site-packages`, which causes problems with build tooling such as Bazel where it's treating `tests` as a third party import and conflicting with our own test suite. 

```
(venv) ➜  /tmp ls -l ./venv/lib/python3.12/site-packages/
total 72
...
drwxr-xr-x  19 finlaysawyer  wheel    608 Sep 18 18:07 pynamodb
drwxr-xr-x   8 finlaysawyer  wheel    256 Sep 18 18:07 pynamodb-6.0.1.dist-info
drwxr-xr-x  17 finlaysawyer  wheel    544 Sep 18 18:07 pynamodb_attributes
drwxr-xr-x   9 finlaysawyer  wheel    288 Sep 18 18:07 pynamodb_attributes-0.5.0.dist-info
drwxr-xr-x  19 finlaysawyer  wheel    608 Sep 18 18:07 tests <--------
```